### PR TITLE
Fix Force Maintaince Padding

### DIFF
--- a/rules/style.css
+++ b/rules/style.css
@@ -70,6 +70,10 @@ nav.TOC a, nav.TOC a:visited {
   text-decoration: none;
 }
 
+.description {
+  margin-bottom: 0.5em;
+}
+
 /* *** Fixes *** */
 
 .likesubsubsectionHead, .subsubsectionHead {


### PR DESCRIPTION
Adds padding below `description` elements to match padding below `itemize` elements

Before:
![image](https://github.com/Eudicods/outworlds-wastes/assets/25011573/5799c02c-32e8-402e-9800-c755bd19b75a)

After:
![image](https://github.com/Eudicods/outworlds-wastes/assets/25011573/624c9066-f53e-4b4e-800b-9a1529467047)
