### PR TITLE
Condense sample tracking pages

### DIFF
--- a/rules/battletech-outworlds-wastes-web.cfg
+++ b/rules/battletech-outworlds-wastes-web.cfg
@@ -15,7 +15,7 @@
   % container for the page toc
   \Configure{tableofcontents}{\IgnorePar\EndP\HCode{<nav class="TOC">}\IgnorePar}
   {\HCode{\Hnewline}}{\IgnorePar\HCode{</nav>\Hnewline}\ShowPar}{}{}%
-  \TableOfContents[section,subsection]% Print table of contents before crosslinks
+  \TableOfContents[section]% Print table of contents before crosslinks
   \egroup
   \ifvmode\IgnorePar\fi\EndP%
   \HCode{<main class="main-content">\Hnewline<nav class="crosslinks-top">} }

--- a/rules/battletech-outworlds-wastes-web.cfg
+++ b/rules/battletech-outworlds-wastes-web.cfg
@@ -24,14 +24,29 @@
   \HCode{<nav class="crosslinks-bottom">}}{\HCode{</nav>}}{}{}
 
 % configuration for TOC on the main page
-\Configure{tableofcontents}{\IgnorePar\EndP\HCode{<nav class="TOC main">}\IgnorePar}
-{}{\IgnorePar\HCode{</nav>\Hnewline<main class="main-content" hidden="">\Hnewline}\ShowPar}{}{}%
+\Configure{tableofcontents}
+  {\IgnorePar\EndP\HCode{<nav class="TOC main">}\IgnorePar}
+  {}
+  {\IgnorePar\HCode{</nav>\Hnewline<main class="main-content" hidden="">\Hnewline}\ShowPar}
+  {}{}
 
 % close the <main> element started in \Configure{crosslinks+}
 \Configure{@/BODY}{\ifvmode\IgnorePar\fi\EndP\HCode{</main>}}
 
 % show only crosslinks to prev, main and next pages
-\Configure{crosslinks*}{prev}{up}{next}{}
+\Configure{crosslinks*}
+  {prev}
+  {up}
+  {next}
+  {}
+
+% Use full words for crosslinks
+\Configure{crosslinks} 
+  {[}{]}
+  {Next Section} 
+  {Last Section}
+  {}{}{}
+  {Home}
 
 % paragraphs
 \Configure{HtmlPar}

--- a/rules/battletech-outworlds-wastes-web.cfg
+++ b/rules/battletech-outworlds-wastes-web.cfg
@@ -9,12 +9,22 @@
 % external stylesheet
 \Configure{AddCss}{style.css}
 
-% Mini TOC
+% ToC number spacing
+\ConfigureToc{section}
+  {\HCode{<span class='sectionToc'><span class="TOC-number">}}
+  {\HCode{</span>}}
+  {}
+  {\HCode{</span>\Hnewline}}
+
+% Mini ToC
 \Configure{crosslinks+}{%
   \bgroup
-  % container for the page toc
-  \Configure{tableofcontents}{\IgnorePar\EndP\HCode{<nav class="TOC">}\IgnorePar}
-  {\HCode{\Hnewline}}{\IgnorePar\HCode{</nav>\Hnewline}\ShowPar}{}{}%
+  % container for the page ToC
+  \Configure{tableofcontents}
+    {\IgnorePar\EndP\HCode{<nav class="TOC">}\IgnorePar}
+    {\HCode{\Hnewline}}
+    {\IgnorePar\HCode{</nav>\Hnewline}\ShowPar}
+    {}{}%
   \TableOfContents[section]% Print table of contents before crosslinks
   \egroup
   \ifvmode\IgnorePar\fi\EndP%
@@ -23,7 +33,7 @@
 {\ifvmode\IgnorePar\fi\EndP%
   \HCode{<nav class="crosslinks-bottom">}}{\HCode{</nav>}}{}{}
 
-% configuration for TOC on the main page
+% configuration for ToC on the main page
 \Configure{tableofcontents}
   {\IgnorePar\EndP\HCode{<nav class="TOC main">}\IgnorePar}
   {}
@@ -54,4 +64,7 @@
     {\HCode{</p>}}{\HCode{</p>}}
 
 \begin{document}
+
+\TocAt{section,subsection}
+
 \EndPreamble

--- a/rules/battletech-outworlds-wastes-web.tex
+++ b/rules/battletech-outworlds-wastes-web.tex
@@ -117,34 +117,28 @@
 \newpage
 
 % --------------------------------------------------------------------------------
-\newsection{Sample Force Roster}{sample-force-roster}
+\newsection{Sample Tracking}{sample-tracking}
 % --------------------------------------------------------------------------------
+
+\subsection{Force Roster}
 
 \input{6-Resources/1-Roster.tex}
 
-\newpage
-
-% --------------------------------------------------------------------------------
-\newsection{Sample Scenario Logistics Tracking}{sample-logistics}
-% --------------------------------------------------------------------------------
+\subsection{Logistics Tracking}
 
 \input{6-Resources/2-Logistics.tex}
 
+\subsection{Dropship Customization}
+
+\input{6-Resources/3-Dropship.tex}
+
 \newpage
 
 % --------------------------------------------------------------------------------
-\newsection{Sample Event Scenario Logistics Tracking}{sample-logistics-event}
+\newsection{Sample Event Tracking}{sample-tracking-event}
 % --------------------------------------------------------------------------------
 
 \input{6-Resources/6-Event-Logistics.tex}
-
-\newpage
-
-% --------------------------------------------------------------------------------
-\newsection{Sample Dropship Customization Tracking}{sample-dropship}
-% --------------------------------------------------------------------------------
-
-\input{6-Resources/3-Dropship.tex}
 
 \newpage
 

--- a/rules/style.css
+++ b/rules/style.css
@@ -66,6 +66,11 @@ nav.TOC span {
   font-size: 1rem;
 }
 
+nav.TOC .TOC-number {
+  display: inline-block;
+  width: 1.5em;
+}
+
 nav.TOC a, nav.TOC a:visited {
   text-decoration: none;
 }


### PR DESCRIPTION
2 pages is better than 4 here.

Tidied up the ToC alignment in the sidebar and put local ToC at the head of each page, if needed.