### PR TITLE
feat: add dark mode

### DIFF
--- a/rules/style.css
+++ b/rules/style.css
@@ -125,7 +125,7 @@ nav.TOC.main {
     width: 100vw;
   }
 
-  figure>p>img {
+  figure > p > img {
     max-width: 100%;
     height: 100%;
     margin: 1rem auto;
@@ -140,9 +140,7 @@ nav.TOC.main {
 /* *** Colors *** */
 
 :root {
-  color-scheme: light dark; /* Default supports both light and dark schemes */
-
-  /* Light mode default variables */
+  color-scheme: light dark;
   --main-background-color: #ccc5b3;
   --accent-background-color: #313831;
   --table-header-background-color: #b2b2b2;
@@ -152,9 +150,9 @@ nav.TOC.main {
 
 @media (prefers-color-scheme: light) {
   :root {
-    /* Light theme styles */
     --main-background-color: #ccc5b3;
     --accent-background-color: #313831;
+    --table-header-background-color: #b2b2b2;
     --text-background-color: #ffffff;
     --text-color: #000000;
   }
@@ -162,8 +160,9 @@ nav.TOC.main {
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --main-background-color: #4d4533;
-    --accent-background-color: #c6cdc6;
+    --main-background-color: #313831;
+    --accent-background-color: #ccc5b3;
+    --table-header-background-color: #313831;
     --text-background-color: #000000;
     --text-color: #ffffff;
   }

--- a/rules/style.css
+++ b/rules/style.css
@@ -10,7 +10,8 @@ body {
     display: grid;
     grid-template-columns: 15rem 1fr;
   }
-  main.main-content, div.footnotes {
+  main.main-content,
+  div.footnotes {
     max-width: 40rem;
     grid-column: 2;
   }
@@ -26,17 +27,22 @@ main.main-content {
   padding: 1rem;
 }
 
-p.indent, p.noindent {
+p.indent,
+p.noindent {
   text-indent: 0;
 }
 
-figure.texsource, figure.shellcommand, figure.htmlsource, figure.luasource, figure.textsource {
+figure.texsource,
+figure.shellcommand,
+figure.htmlsource,
+figure.luasource,
+figure.textsource {
   margin: 0.5rem 0;
   padding-left: 0.5rem;
   overflow: auto;
 }
 
-figure pre.listings{
+figure pre.listings {
   font-size: 1em;
 }
 
@@ -45,12 +51,12 @@ figure pre.listings{
   padding: 0;
 }
 
-.sectionToc{
+.sectionToc {
   margin: 0;
   padding: 0;
 }
 
-.subsectionToc{
+.subsectionToc {
   margin: 0;
   padding: 0em 0em 0em 1em;
 }
@@ -71,7 +77,8 @@ nav.TOC .TOC-number {
   width: 1.5em;
 }
 
-nav.TOC a, nav.TOC a:visited {
+nav.TOC a,
+nav.TOC a:visited {
   text-decoration: none;
 }
 
@@ -81,7 +88,8 @@ nav.TOC a, nav.TOC a:visited {
 
 /* *** Fixes *** */
 
-.likesubsubsectionHead, .subsubsectionHead {
+.likesubsubsectionHead,
+.subsubsectionHead {
   font-size: 100%;
 }
 
@@ -124,18 +132,35 @@ nav.TOC.main {
   }
 }
 
-
 /* *** Colors *** */
 
 :root {
+  color-scheme: light dark; /* Default supports both light and dark schemes */
+
+  /* Light mode default variables */
   --main-background-color: #ccc5b3;
   --accent-background-color: #313831;
   --text-background-color: #ffffff;
   --text-color: #000000;
 }
 
-:root {
-  color-scheme: light;
+@media (prefers-color-scheme: light) {
+  :root {
+    /* Light theme styles */
+    --main-background-color: #ccc5b3;
+    --accent-background-color: #313831;
+    --text-background-color: #ffffff;
+    --text-color: #000000;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --main-background-color: #4d4533;
+    --accent-background-color: #c6cdc6;
+    --text-background-color: #000000;
+    --text-color: #ffffff;
+  }
 }
 
 body {
@@ -143,20 +168,28 @@ body {
   background-color: var(--main-background-color);
 }
 
-main.main-content, div.footnotes {
+main.main-content,
+div.footnotes {
   background-color: var(--text-background-color);
 }
 
-nav.TOC, nav.TOC a, nav.TOC a:visited {
+nav.TOC,
+nav.TOC a,
+nav.TOC a:visited {
   background-color: var(--accent-background-color);
   color: var(--main-background-color);
 }
 
-nav.TOC span:hover, nav.TOC span:hover *{
+nav.TOC span:hover,
+nav.TOC span:hover * {
   background-color: var(--accent-background-color);
 }
 
-figure.texsource, figure.shellcommand, figure.htmlsource, figure.luasource, figure.textsource{
+figure.texsource,
+figure.shellcommand,
+figure.htmlsource,
+figure.luasource,
+figure.textsource {
   border: 1px solid var(--main-background-color);
   background-color: var(--accent-background-color);
 }


### PR DESCRIPTION
This pull request addresses and closes issue #114 . 

It introduces a new feature that serves a dark mode/theme based on the visitor's system-level preferences. If the visitor's system is set to dark mode, the dark theme will be applied automatically, otherwise, the default light theme will be used.

Changes Introduced
- Dark mode/theme implementation: The theme now dynamically adjusts based on the user's system preferences (using the prefers-color-scheme CSS media query).
- Default behavior: If no system preference for dark mode is detected, the website will continue to use the original light theme.
- Accessibility testing: The dark theme has been tested for accessibility using Chrome’s Lighthouse tool, with no accessibility issues reported.

Testing & Verification
Verified the dark theme using both manual testing and Chrome's Lighthouse tool.(screenshots attached for reference)
No performance or accessibility issues were found in the Lighthouse audit.

<img width="1089" alt="Screenshot 2024-10-02 at 00 30 43" src="https://github.com/user-attachments/assets/95d3782f-eda1-4753-9341-fbaaf750ac5f">
<img width="1091" alt="Screenshot 2024-10-02 at 00 31 23" src="https://github.com/user-attachments/assets/fd02b69a-403a-4aab-9f74-827dc81dec39">
